### PR TITLE
Update documentation due to error with Vagrant < 1.8.

### DIFF
--- a/automated/development-env.rst
+++ b/automated/development-env.rst
@@ -8,7 +8,7 @@ virtual machine with sources rsync-ed between the host and the guest.
 Requirements
 ````````````
 
-- `Vagrant <http://www.vagrantup.com/>`_ 1.5 or higher has to be installed
+- `Vagrant <http://www.vagrantup.com/>`_ 1.8 or higher has to be installed
 - As the installation work only for `Virtualbox <https://www.virtualbox.org/>`_,
   you will need to install it
 - `Rsync <https://rsync.samba.org/>`_ to synchronize directories from host to VMs

--- a/automated/testing-env.rst
+++ b/automated/testing-env.rst
@@ -7,7 +7,7 @@ virtual machine, merely for testing purposes.
 Requirements
 ````````````
 
-- `Vagrant <http://www.vagrantup.com/>`_ 1.5 or higher has to be installed.
+- `Vagrant <http://www.vagrantup.com/>`_ 1.8 or higher has to be installed.
 - As the installation work only for `Virtualbox <https://www.virtualbox.org/>`_,
   you will need to install it.
 


### PR DESCRIPTION
With the new Vagrant "ansible.force_remote_user" option set to true by
default, SSH User used to connect to the VM is now set to "vagrant" into
the Ansible inventory (generated by Vagrant).
This behavior does not permit to use Ansible "remote_user" option into
playbooks (overridden by the inventory), that's the reason why the
deployment fail.