### PR TITLE
Install pip with get-pip.py

### DIFF
--- a/ansible/roles/quarkslab.irma_provisioning_common/tasks/debian_install_packages.yml
+++ b/ansible/roles/quarkslab.irma_provisioning_common/tasks/debian_install_packages.yml
@@ -6,7 +6,24 @@
     - vim
     - aria2
     - git
-    - python-pip
-    - python-virtualenv
     - python-dev
     - unzip
+    - make
+
+# Install python-pip (cause the debian version is only 1.1)
+- name: Downloading script get-pip.py
+  get_url:
+    url: 'https://bootstrap.pypa.io/get-pip.py'
+    dest: '/tmp'
+
+- name: Installing pip
+  command: python get-pip.py
+  args:
+   chdir: '/tmp'
+
+
+# Install virtualenv
+- name: Install virtualenv with pip
+  pip: name={{ item }} state=present
+  with_items:
+    - virtualenv


### PR DESCRIPTION
pip version is only 1.1-3 on debian wheezy.
Installing requirements in virtualenv failed during deployment with this version of pip.

Solution: 
get a recent version of pip with get-pip.py
download virtualenv with pip.

Thanks.
