### PR TITLE
[Feature] Add AVs tag to submitted files if detected as infected

### DIFF
--- a/frontend/frontend/tasks.py
+++ b/frontend/frontend/tasks.py
@@ -75,6 +75,7 @@ def scan_result(scanid, file_hash, probe, result):
                   scanid, file_hash, probe)
         scan_ctrl.handle_output_files(scanid, file_hash, probe, result)
         scan_ctrl.set_result(scanid, file_hash, probe, result)
+        scan_ctrl.set_probe_tag(file_hash, probe, result)
     except IrmaDatabaseError as e:
         log.exception(e)
         raise scan_result.retry(countdown=2, max_retries=3, exc=e)

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -326,6 +326,10 @@ paths:
           description: A limit on the number of objects to be returned.
           type: integer
           format: int64
+        - name: alt
+          in: query
+          description: When value is "media" response will be a zip archive containing all files matching the research.
+          type: string
       responses:
         '200':
           description: OK

--- a/frontend/swagger/ui/swagger.json
+++ b/frontend/swagger/ui/swagger.json
@@ -460,6 +460,12 @@
                         "description": "A limit on the number of objects to be returned.",
                         "type": "integer",
                         "format": "int64"
+                    },
+                    {
+                        "name": "alt",
+                        "in": "query",
+                        "description": "When value is \"media\" response will be a zip archive containing all files matching the research.",
+                        "type": "string"
                     }
                 ],
                 "responses": {


### PR DESCRIPTION
A tag is automatically added to a submitted file if detected as infected.
Only Antivirus probe tag are added.

You can still remove the tag through the API or interface.
Thx.
![irma_pr](https://cloud.githubusercontent.com/assets/19646203/21233524/bc34ec50-c2ef-11e6-82e9-82a3e16e88b6.png)
