### PR TITLE
[Feature] Add AVs tag to submitted files if detected as infected.

### DIFF
--- a/frontend/frontend/tasks.py
+++ b/frontend/frontend/tasks.py
@@ -75,6 +75,7 @@ def scan_result(scanid, file_hash, probe, result):
                   scanid, file_hash, probe)
         scan_ctrl.handle_output_files(scanid, file_hash, probe, result)
         scan_ctrl.set_result(scanid, file_hash, probe, result)
+        scan_ctrl.set_probe_tag(file_hash, probe, result)
     except IrmaDatabaseError as e:
         log.exception(e)
         raise scan_result.retry(countdown=2, max_retries=3, exc=e)


### PR DESCRIPTION
A tag is automatically added to a submitted file if detected as infected.
Only Antivirus probe tag are added.

You can still remove the tag through the API or interface.
Thx.

![irma_pr](https://cloud.githubusercontent.com/assets/19646203/21266499/c3bfcb68-c3a6-11e6-8d73-ad99e2203077.png)
