### PR TITLE
[Feature] Antivirus statistics

### DIFF
--- a/frontend/frontend/api/v1_1/controllers/stats.py
+++ b/frontend/frontend/api/v1_1/controllers/stats.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2013-2016 Quarkslab.
+# This file is part of IRMA project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the top-level directory
+# of this distribution and at:
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# No part of the project, including this file, may be copied,
+# modified, propagated, or distributed except according to the
+# terms contained in the LICENSE file.
+
+import logging
+from bottle import response, request
+
+from frontend.api.v1_1.errors import process_error
+from frontend.helpers.utils import guess_hash_type
+from frontend.models.sqlobjects import FileWeb, File
+from frontend.api.v1_1.schemas import FileWebSchema_v1_1, ScanSchema_v1_1, \
+    FileSchema_v1_1
+from lib.common.utils import decode_utf8
+from lib.irma.common.exceptions import IrmaDatabaseResultNotFound
+
+
+file_web_schema = FileWebSchema_v1_1()
+scan_schema = ScanSchema_v1_1()
+file_web_schema.context = {'formatted': True}
+log = logging.getLogger(__name__)
+
+
+
+def get_stats(db):
+    """ Get statistics on submitted files using query filters (tags + hash or name).
+    :param all params are sent using query method
+    :rtype: dict of 'total': int, 'page': int, 'per_page': int,
+        'items': list of file(s) found
+    :return:
+        on success 'items' contains a statistics by avs.
+        on error 'msg' gives reason message
+    """
+    try:
+        name = None
+        if 'name' in request.query:
+            name = decode_utf8(request.query['name'])
+
+        h_value = request.query.get('hash')
+
+        search_tags = request.query.get('tags')
+        if search_tags is not None:
+            search_tags = search_tags.split(',')
+
+        log.debug("name %s h_value %s search_tags %s",
+                  name, h_value, search_tags)
+        if name is not None and h_value is not None:
+            raise ValueError("Can't find using both name and hash")
+
+        # Get values from query or default
+        offset = request.query.get("offset", default=0)
+        offset = int(offset)
+        limit = request.query.get("limit", default=0)
+        limit = int(limit)
+
+
+        if name is not None:
+            base_query = FileWeb.query_find_by_name(name, search_tags, db)
+        elif h_value is not None:
+            h_type = guess_hash_type(h_value)
+
+            if h_type is None:
+                raise ValueError("Hash not supported")
+
+            base_query = FileWeb.query_find_by_hash(
+                h_type, h_value, search_tags, db)
+        else:
+            # FIXME this is just a temporary way to output
+            # all files, need a dedicated
+            # file route and controller
+            base_query = FileWeb.query_find_by_name("", search_tags, db)
+
+        # TODO: Find a way to move pagination as a BaseQuery like in
+        #       flask_sqlalchemy.
+        # https://github.com/mitsuhiko/flask-sqlalchemy/blob/master/flask_sqlalchemy/__init__.py#L422
+        items = base_query.all()
+        #items = base_query.limit(limit).offset(offset).all()
+
+        files_infos = file_web_schema.dump(items, many=True).data
+
+
+        stats = []
+
+        # Get scan result for each file
+        for i, val in enumerate(files_infos):
+
+            probe_results = val['probe_results']
+
+            for j, res in enumerate(probe_results):
+
+                if res.type == "antivirus":
+                    add_stats(stats,res)
+
+
+        if offset == 0 and len(items) < limit:
+            total = len(items)
+        else:
+            total = base_query.count()
+
+        log.debug("Found %s results", total)
+        response.content_type = "application/json; charset=UTF-8"
+        return {
+            'total': total,
+            'offset': offset,
+            'limit': limit,
+            'items': stats,
+        }
+    except Exception as e:
+        log.exception(e)
+        process_error(e)
+
+
+
+def add_stats(stats, result):
+
+    
+    for i, val in enumerate(stats):
+        
+        if val['name'] == result.name:
+            # update stats.
+            val['total'] += 1
+            val['infected'] = val['infected']+1 if result.status == 1 else val['infected']
+            val['clean'] = val['clean']+1 if result.status == 0 else val['clean']
+            val['errors'] = val['errors']+1 if result.status == -1 else val['errors']
+            return 1
+
+
+    # add new entry in av stats:
+    av = {  
+        "name":result.name,
+        "version": result.version,
+        "total": 1,
+        "infected": 1 if result.status == 1 else 0 ,
+        "clean": 1 if result.status == 0 else 0 ,
+        "errors": 1 if result.status == -1 else 0
+    }
+
+    stats.append(av)
+    
+    
+    return 0

--- a/frontend/frontend/api/v1_1/routes.py
+++ b/frontend/frontend/api/v1_1/routes.py
@@ -13,7 +13,7 @@
 # modified, propagated, or distributed except according to the
 # terms contained in the LICENSE file.
 
-from frontend.api.v1_1.controllers import probes, files, scans, results, tags
+from frontend.api.v1_1.controllers import probes, files, scans, results, tags, stats
 
 
 """ Define all routes for the API
@@ -56,3 +56,7 @@ def define_routes(application):
                       callback=files.add_tag)
     application.route("/files/<sha256>/tags/<tagid>/remove",
                       callback=files.remove_tag)
+
+    # Statistics routes
+    application.route("/stats",
+                      callback=stats.get_stats)

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -444,6 +444,59 @@ paths:
          description: OK
          schema:
           $ref: '#/definitions/Tag'
+  '/stats':
+    get:
+      summary: Get antivirus statistics
+      description: |
+        Get antivirus statistics on submitted files.
+      tags:
+        - Stats
+      parameters:
+        - name: hash
+          in: query
+          description: 'Hash value (can be md5, sha1 or sha256)'
+          type: string
+        - name: name
+          in: query
+          description: Filename or regexp
+          type: string
+        - name: tag
+          in: query
+          description: list of existing tags id comma separated
+          type: string
+        - name: offset
+          in: query
+          description: Offset the list of returned objects. Default is zero.
+          type: integer
+          format: int64
+        - name: limit
+          in: query
+          description: A limit on the number of objects to be returned.
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: OK
+          schema:
+            type: object
+            properties:
+              total:
+                type: integer
+                format: int64
+              offset:
+                type: integer
+                format: int64
+              limit:
+                type: integer
+                format: int64
+              items:
+                type: array
+                items:
+                  $ref: '#/definitions/AvStats'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
 
 definitions:
   Scan:
@@ -597,6 +650,22 @@ definitions:
         format: double
       text:
         type: string
+
+  AvStats:
+    type: object
+    properties:
+      name:
+        type: string
+      version:
+        type: string
+      infected:
+        type: integer
+      clean:
+        type: integer
+      errors:
+        type: integer
+      total:
+        type: integer
 
   Error:
     type: object

--- a/frontend/swagger/ui/swagger.json
+++ b/frontend/swagger/ui/swagger.json
@@ -578,6 +578,83 @@
                     }
                 }
             }
+        },
+        "/stats": {
+            "get": {
+                "summary": "Get antivirus statistics",
+                "description": "Get antivirus statistics on submitted files.",
+                "tags": [
+                    "Stats"
+                ],
+                "parameters": [
+                    {
+                        "name": "hash",
+                        "in": "query",
+                        "description": "Hash value (can be md5, sha1 or sha256)",
+                        "type": "string"
+                    },
+                    {
+                        "name": "name",
+                        "in": "query",
+                        "description": "Filename or regexp",
+                        "type": "string"
+                    },
+                    {
+                        "name": "tag",
+                        "in": "query",
+                        "description": "list of existing tags id comma separated",
+                        "type": "string"
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "Offset the list of returned objects. Default is zero.",
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "A limit on the number of objects to be returned.",
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "total": {
+                                    "type": "integer",
+                                    "format": "int64"
+                                },
+                                "offset": {
+                                    "type": "integer",
+                                    "format": "int64"
+                                },
+                                "limit": {
+                                    "type": "integer",
+                                    "format": "int64"
+                                },
+                                "items": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/AvStats"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -792,6 +869,29 @@
                 },
                 "text": {
                     "type": "string"
+                }
+            }
+        },
+        "AvStats": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                },
+                "infected": {
+                    "type": "integer"
+                },
+                "clean": {
+                    "type": "integer"
+                },
+                "errors": {
+                    "type": "integer"
+                },
+                "total": {
+                    "type": "integer"
                 }
             }
         },


### PR DESCRIPTION
Add antivirus statistics to API.

Av stats struct:
- Name (Antivirus name)
- Version (Antivirus version)
- Infected (Number of files detected as infected)
- Clean (Number of clean files)
- Errors (Number of files analyzed with errors)
- Total (Number of analyzed files with this probe

Screenshots:

![irma_pr4](https://cloud.githubusercontent.com/assets/19646203/21313139/55d30286-c5f0-11e6-9ab4-24a74d33c157.png)

![irma_pr4_2](https://cloud.githubusercontent.com/assets/19646203/21313205/b7b2d86e-c5f0-11e6-9104-5e679a557c5f.png)


Thx.
