### PR TITLE
[Feature] Add already uploaded files to a scan

### DIFF
--- a/frontend/frontend/api/v1_1/controllers/scans.py
+++ b/frontend/frontend/api/v1_1/controllers/scans.py
@@ -189,6 +189,31 @@ def add_files(scanid, db):
         process_error(e)
 
 
+def add_files_ext(scanid, db):
+    """ Attach existing files to a scan.
+        The request should be performed using a POST request method.
+    """
+    try:
+        log.debug("scanid %s", scanid)
+        validate_id(scanid)
+        scan = Scan.load_from_ext_id(scanid, db)
+
+        # Get scan parameters (array of files description)
+        if request.json is not None:
+            files_array = request.json
+        else:
+            raise ValueError("No files to attach")
+
+        # Add files to a scan
+        scan_ctrl.add_files_ext(scan, files_array, db)
+
+        response.content_type = "application/json; charset=UTF-8"
+        return scan_schema.dumps(scan).data
+    except Exception as e:
+        log.exception(e)
+        process_error(e)
+
+
 def get_results(scanid, db):
     """ Retrieve results for a scan. Results are the same as in the get()
         method, i.e. a summary for each scanned files.

--- a/frontend/frontend/api/v1_1/routes.py
+++ b/frontend/frontend/api/v1_1/routes.py
@@ -33,6 +33,8 @@ def define_routes(application):
                       callback=scans.get)
     application.route("/scans/<scanid>/files", method="POST",
                       callback=scans.add_files)
+    application.route("/scans/<scanid>/files_ext", method="POST",
+                      callback=scans.add_files_ext)
     application.route("/scans/<scanid>/launch", method="POST",
                       callback=scans.launch)
     application.route("/scans/<scanid>/cancel", method="POST",

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -184,6 +184,35 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
+  '/scans/{scanId}/files_ext':
+    post:
+      summary: Create a file upload with existing files
+      description: |
+        Add already submitted files to a specific scan.
+      tags:
+        - Scans
+      parameters:
+        - name: scanId
+          in: path
+          type: string
+          description: ID of the scan
+          required: true
+        - name: files
+          in: body
+          type: array
+          description: Files to add to the scan
+          schema:
+            $ref: '#/definitions/ScanFiles'
+          required: true
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Scan'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
   '/scans/{scanId}/results':
     get:
       summary: List all results from a scan
@@ -588,6 +617,12 @@ definitions:
       resubmit_files:
         type: boolean
         default: True
+
+  ScanFiles:
+    type: object
+    properties:
+      sha256:
+        type: string
 
   Tag:
     type: object

--- a/frontend/swagger/ui/swagger.json
+++ b/frontend/swagger/ui/swagger.json
@@ -263,6 +263,48 @@
                 }
             }
         },
+        "/scans/{scanId}/files_ext": {
+            "post": {
+                "summary": "Create a file upload with existing files",
+                "description": "Add already submitted files to a specific scan.\n",
+                "tags": [
+                    "Scans"
+                ],
+                "parameters": [
+                    {
+                        "name": "scanId",
+                        "in": "path",
+                        "type": "string",
+                        "description": "ID of the scan",
+                        "required": true
+                    },
+                    {
+                        "name": "files",
+                        "in": "body",
+                        "type": "array",
+                        "description": "Files to add to the scan",
+                        "schema": {
+                            "$ref": "#/definitions/ScanFiles"
+                        },
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/Scan"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
         "/scans/{scanId}/results": {
             "get": {
                 "summary": "List all results from a scan",
@@ -780,6 +822,14 @@
                 "resubmit_files": {
                     "type": "boolean",
                     "default": true
+                }
+            }
+        },
+        "ScanFiles": {
+            "type": "object",
+            "properties": {
+                "sha256": {
+                    "type": "string"
                 }
             }
         },


### PR DESCRIPTION
Add new feature in the API to add already uploaded file to scan.
A list of files description (sha256: value) is provided as argument to the post request (see swagger scheme)

This feature would be useful to launch an analysis on files already submitted.
Api test usage:
-> api/v1.1/scans [POST]
-> api/v1.1/scans/{scanId}/files_ext [POST]
-> api/v1.1/scans/{scanId}/launch [POST]

Screenshots:
![irma_pr5_2](https://cloud.githubusercontent.com/assets/19646203/21392282/6c685b68-c78f-11e6-8de9-45b2e95f1022.png)


Thx. 
